### PR TITLE
docs: tidy all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-<h1>Retrieval-based-Voice-Conversion-WebUI</h1>
+# Retrieval-based-Voice-Conversion-WebUI
 一个基于VITS的简单易用的变声框架<br><br>
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange
 )](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Licence](https://img.shields.io/badge/LICENSE-MIT-green.svg?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -25,24 +25,11 @@
 
 > 由于某些地区无法直连Hugging Face，即使设法成功访问，速度也十分缓慢，特推出模型/整合包/工具的一键下载器，欢迎试用：[RVC-Models-Downloader](https://github.com/fumiama/RVC-Models-Downloader)
 
-<table>
-   <tr>
-		<td align="center">训练推理界面</td>
-		<td align="center">实时变声界面</td>
-	</tr>
-  <tr>
-		<td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630"></td>
-    <td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6"></td>
-	</tr>
-	<tr>
-		<td align="center">go-web.bat</td>
-		<td align="center">go-realtime-gui.bat</td>
-	</tr>
-  <tr>
-    <td align="center">可以自由选择想要执行的操作。</td>
-	<td align="center">我们已经实现端到端170ms延迟。如使用ASIO输入输出设备，已能实现端到端90ms延迟，但非常依赖硬件驱动支持。</td>
-	</tr>
-</table>
+| 训练推理界面 | 实时变声界面 |
+| :--------: | :---------: |
+| ![web](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630) | ![realtime-gui](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6) |
+| go-web.bat | go-realtime-gui.bat |
+| 可以自由选择想要执行的操作。 | 我们已经实现端到端170ms延迟。如使用ASIO输入输出设备，已能实现端到端90ms延迟，但非常依赖硬件驱动支持。|
 
 ## 简介
 本仓库具有以下特点
@@ -227,6 +214,4 @@ rvcmd packs/general/latest # RVC-Models-Downloader command
   + The pretrained model is trained and tested by [yxlllc](https://github.com/yxlllc/RMVPE) and [RVC-Boss](https://github.com/RVC-Boss).
 
 ## 感谢所有贡献者作出的努力
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)

--- a/docs/en/README.en.md
+++ b/docs/en/README.en.md
@@ -74,19 +74,19 @@ sh ./run.sh
 3. Install the corresponding dependencies according to your own graphics card.
 - Nvidia GPU
 	```bash
-	pip install -r requirements/requirements.txt
+	pip install -r requirements/main.txt
 	```
 - AMD/Intel GPU
 	```bash
-	pip install -r requirements/requirements-dml.txt
+	pip install -r requirements/dml.txt
 	```
 - AMD ROCM (Linux)
 	```bash
-	pip install -r requirements/requirements-amd.txt
+	pip install -r requirements/amd.txt
 	```
 - Intel IPEX (Linux)
 	```bash
-	pip install -r requirements/requirements-ipex.txt
+	pip install -r requirements/ipex.txt
 	```
 
 ## Preparation of Other Files

--- a/docs/en/README.en.md
+++ b/docs/en/README.en.md
@@ -1,12 +1,14 @@
 <div align="center">
 
-<h1>Retrieval-based-Voice-Conversion-WebUI</h1>
-An easy-to-use voice conversion framework based on VITS.<br><br>
+# Retrieval-based-Voice-Conversion-WebUI
+An easy-to-use voice conversion framework based on VITS.
+
+
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange
 )](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Licence](https://img.shields.io/github/license/fumiama/Retrieval-based-Voice-Conversion-WebUI?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -25,24 +27,11 @@ An easy-to-use voice conversion framework based on VITS.<br><br>
 
 > There's a [one-click downloader](https://github.com/fumiama/RVC-Models-Downloader) for models/integration packages/tools. Welcome to try.
 
-<table>
-   <tr>
-		<td align="center">Training and inference Webui</td>
-		<td align="center">Real-time voice changing GUI</td>
-	</tr>
-  <tr>
-		<td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630"></td>
-    <td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6"></td>
-	</tr>
-	<tr>
-		<td align="center">go-web.bat</td>
-		<td align="center">go-realtime-gui.bat</td>
-	</tr>
-  <tr>
-    <td align="center">You can freely choose the action you want to perform.</td>
-		<td align="center">We have achieved an end-to-end latency of 170ms. With the use of ASIO input and output devices, we have managed to achieve an end-to-end latency of 90ms, but it is highly dependent on hardware driver support.</td>
-	</tr>
-</table>
+| Training and inference Webui | Real-time voice changing GUI |
+| :--------: | :---------: |
+| ![web](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630) | ![realtime-gui](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6) |
+| go-web.bat | go-realtime-gui.bat |
+| You can freely choose the action you want to perform. | We have achieved an end-to-end latency of 170ms. With the use of ASIO input and output devices, we have managed to achieve an end-to-end latency of 90ms, but it is highly dependent on hardware driver support. |
 
 ## Features:
 + Reduce tone leakage by replacing the source feature to training-set feature using top1 retrieval;
@@ -225,6 +214,4 @@ rvcmd packs/general/latest # RVC-Models-Downloader command
   + The pretrained model is trained and tested by [yxlllc](https://github.com/yxlllc/RMVPE) and [RVC-Boss](https://github.com/RVC-Boss).
 
 ## Thanks to all contributors for their efforts
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)

--- a/docs/fr/README.fr.md
+++ b/docs/fr/README.fr.md
@@ -72,16 +72,16 @@ poetry install
 Ou vous pouvez utiliser pip pour installer les dépendances :
 ```bash
 # Cartes Nvidia :
-pip install -r requirements/requirements.txt
+pip install -r requirements/main.txt
 
 # Cartes AMD/Intel :
-pip install -r requirements/requirements-dml.txt
+pip install -r requirements/dml.txt
 
 # Cartes Intel avec IPEX
-pip install -r requirements/requirements-ipex.txt
+pip install -r requirements/ipex.txt
 
 # Cartes AMD sur Linux (ROCm)
-pip install -r requirements/requirements-amd.txt
+pip install -r requirements/amd.txt
 ```
 
 ------

--- a/docs/fr/README.fr.md
+++ b/docs/fr/README.fr.md
@@ -1,12 +1,14 @@
 <div align="center">
 
-<h1>Retrieval-based-Voice-Conversion-WebUI</h1>
-Un framework simple et facile à utiliser pour la conversion vocale (modificateur de voix) basé sur VITS<br><br>
+# Retrieval-based-Voice-Conversion-WebUI
+Un framework simple et facile à utiliser pour la conversion vocale (modificateur de voix) basé sur VITS
+
+
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange
 )](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Licence](https://img.shields.io/badge/LICENSE-MIT-green.svg?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -172,6 +174,4 @@ python web.py
   + Le modèle pré-entraîné a été formé et testé par [yxlllc](https://github.com/yxlllc/RMVPE) et [RVC-Boss](https://github.com/RVC-Boss).
 
 ## Remerciements à tous les contributeurs pour leurs efforts
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)

--- a/docs/jp/README.ja.md
+++ b/docs/jp/README.ja.md
@@ -1,11 +1,13 @@
 <div align="center">
 
-<h1>Retrieval-based-Voice-Conversion-WebUI</h1>
-VITSに基づく使いやすい音声変換（voice changer）framework<br><br>
+# Retrieval-based-Voice-Conversion-WebUI
+VITSに基づく使いやすい音声変換（voice changer）framework
+
+
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Licence](https://img.shields.io/badge/LICENSE-MIT-green.svg?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -24,24 +26,11 @@ VITSに基づく使いやすい音声変換（voice changer）framework<br><br>
 
 > モデルや統合パッケージをダウンロードしやすい[RVC-Models-Downloader](https://github.com/fumiama/RVC-Models-Downloader)のご利用がお勧めです。
 
-<table>
-   <tr>
-		<td align="center">学習・推論</td>
-		<td align="center">即時音声変換</td>
-	</tr>
-  <tr>
-		<td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630"></td>
-    <td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6"></td>
-	</tr>
-	<tr>
-		<td align="center">go-web.bat</td>
-		<td align="center">go-realtime-gui.bat</td>
-	</tr>
-  <tr>
-    <td align="center">実行したい操作を自由に選択できます。</td>
-	<td align="center">既に端から端までの170msの遅延を実現しました。ASIO入出力デバイスを使用すれば、端から端までの90msの遅延を達成できますが、ハードウェアドライバーの支援に非常に依存しています。</td>
-	</tr>
-</table>
+| 学習・推論 | 即時音声変換 |
+| :--------: | :---------: |
+| ![web](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630) | ![realtime-gui](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6) |
+| go-web.bat | go-realtime-gui.bat |
+| 実行したい操作を自由に選択できます。 | 既に端から端までの170msの遅延を実現しました。ASIO入出力デバイスを使用すれば、端から端までの90msの遅延を達成できますが、ハードウェアドライバーの支援に非常に依存しています。 |
 
 ## はじめに
 
@@ -230,6 +219,4 @@ rvcmd packs/general/latest # RVC-Models-Downloader command
 
 ## すべての貢献者の努力に感謝します
 
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)

--- a/docs/jp/README.ja.md
+++ b/docs/jp/README.ja.md
@@ -75,19 +75,19 @@ sh ./run.sh
 3. 自分の GPU に対応する依存関係をインストールします。
 - Nvidia GPU
 	```bash
-	pip install -r requirements/requirements.txt
+	pip install -r requirements/main.txt
 	```
 - AMD/Intel GPU
 	```bash
-	pip install -r requirements/requirements-dml.txt
+	pip install -r requirements/dml.txt
 	```
 - AMD ROCM (Linux)
 	```bash
-	pip install -r requirements/requirements-amd.txt
+	pip install -r requirements/amd.txt
 	```
 - Intel IPEX (Linux)
 	```bash
-	pip install -r requirements/requirements-ipex.txt
+	pip install -r requirements/ipex.txt
 	```
 
 ## その他のデータを準備

--- a/docs/kr/README.ko.han.md
+++ b/docs/kr/README.ko.han.md
@@ -1,12 +1,14 @@
 <div align="center">
 
-<h1>Retrieval-based-Voice-Conversion-WebUI</h1>
-VITS基盤의 簡單하고使用하기 쉬운音聲變換틀<br><br>
+# Retrieval-based-Voice-Conversion-WebUI
+VITS基盤의 簡單하고使用하기 쉬운音聲變換틀
+
+
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange
 )](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Licence](https://img.shields.io/github/license/fumiama/Retrieval-based-Voice-Conversion-WebUI?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -98,7 +100,5 @@ Windows를 使用하는境遇 `RVC-beta.7z`를 다운로드 및 壓縮解除하�
 + [audio-slicer](https://github.com/openvpi/audio-slicer)
 ## 모든寄與者분들의勞力에感謝드립니다
 
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)
 

--- a/docs/kr/README.ko.han.md
+++ b/docs/kr/README.ko.han.md
@@ -61,7 +61,7 @@ poetry install
 pip를 活用하여依存를 設置하여도 無妨합니다.
 
 ```bash
-pip install -r requirements/requirements.txt
+pip install -r requirements/main.txt
 ```
 
 ## 其他預備모델準備

--- a/docs/kr/README.ko.md
+++ b/docs/kr/README.ko.md
@@ -1,11 +1,11 @@
 <div align="center">
 
-<h1>Retrieval-based-Voice-Conversion-WebUI</h1>
-VITS 기반의 간단하고 사용하기 쉬운 음성 변환 프레임워크.<br><br>
+# Retrieval-based-Voice-Conversion-WebUI
+VITS 기반의 간단하고 사용하기 쉬운 음성 변환 프레임워크.
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Licence](https://img.shields.io/badge/LICENSE-MIT-green.svg?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -24,24 +24,11 @@ VITS 기반의 간단하고 사용하기 쉬운 음성 변환 프레임워크.<b
 
 > 특정 지역에서 Hugging Face에 직접 연결할 수 없는 경우가 있으며, 성공적으로 연결해도 속도가 매우 느릴 수 있으므로, 모델/통합 패키지/도구의 일괄 다운로더를 특별히 소개합니다. [RVC-Models-Downloader](https://github.com/fumiama/RVC-Models-Downloader)
 
-<table>
-   <tr>
-		<td align="center">훈련 및 추론 인터페이스</td>
-		<td align="center">실시간 음성 변환 인터페이스</td>
-	</tr>
-  <tr>
-		<td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630"></td>
-    <td align="center"><img src="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6"></td>
-	</tr>
-	<tr>
-		<td align="center">go-web.bat</td>
-		<td align="center">go-realtime-gui.bat</td>
-	</tr>
-  <tr>
-    <td align="center">원하는 작업을 자유롭게 선택할 수 있습니다.</td>
-		<td align="center">우리는 이미 끝에서 끝까지 170ms의 지연을 실현했습니다. ASIO 입력 및 출력 장치를 사용하면 끝에서 끝까지 90ms의 지연을 달성할 수 있지만, 이는 하드웨어 드라이버 지원에 매우 의존적입니다.</td>
-	</tr>
-</table>
+| 훈련 및 추론 인터페이스 | 실시간 음성 변환 인터페이스 |
+| :--------: | :---------: |
+| ![web](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/092e5c12-0d49-4168-a590-0b0ef6a4f630) | ![realtime-gui](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/assets/129054828/730b4114-8805-44a1-ab1a-04668f3c30a6) |
+| go-web.bat | go-realtime-gui.bat |
+| 원하는 작업을 자유롭게 선택할 수 있습니다. | 우리는 이미 끝에서 끝까지 170ms의 지연을 실현했습니다. ASIO 입력 및 출력 장치를 사용하면 끝에서 끝까지 90ms의 지연을 달성할 수 있지만, 이는 하드웨어 드라이버 지원에 매우 의존적입니다. |
 
 ## 소개
 
@@ -257,9 +244,7 @@ rvcmd packs/general/latest # RVC-Models-Downloader command
   + The pretrained model is trained and tested by [yxlllc](https://github.com/yxlllc/RMVPE) and [RVC-Boss](https://github.com/RVC-Boss).
 
 ## 感谢所有贡献者作出的努力
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)
 
 translate to Korean
 -->
@@ -415,6 +400,4 @@ source /opt/intel/oneapi/setvars.sh
 
 ## 모든 기여자들의 노력에 감사드립니다
 
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)

--- a/docs/kr/README.ko.md
+++ b/docs/kr/README.ko.md
@@ -72,25 +72,25 @@ pip install torch torchvision torchaudio --index-url https://download.pytorch.or
 - N카드
 
 ```bash
-pip install -r requirements/requirements.txt
+pip install -r requirements/main.txt
 ```
 
 - A카드/I카드
 
 ```bash
-pip install -r requirements/requirements-dml.txt
+pip install -r requirements/dml.txt
 ```
 
 - A카드ROCM(Linux)
 
 ```bash
-pip install -r requirements/requirements-amd.txt
+pip install -r requirements/amd.txt
 ```
 
 - I카드IPEX(Linux)
 
 ```bash
-pip install -r requirements/requirements-ipex.txt
+pip install -r requirements/ipex.txt
 ```
 
 #### 2. poetry를 통한 의존성 설치

--- a/docs/pt/README.pt.md
+++ b/docs/pt/README.pt.md
@@ -79,16 +79,16 @@ Você também pode usar pip para instalá-los:
 ```bash
 
 for Nvidia graphics cards
-  pip install -r requirements/requirements.txt
+  pip install -r requirements/main.txt
 
 for AMD/Intel graphics cards on Windows (DirectML)：
-  pip install -r requirements/requirements-dml.txt
+  pip install -r requirements/dml.txt
 
 for Intel ARC graphics cards on Linux / WSL using Python 3.10: 
-  pip install -r requirements/requirements-ipex.txt
+  pip install -r requirements/ipex.txt
 
 for AMD graphics cards on Linux (ROCm):
-  pip install -r requirements/requirements-amd.txt
+  pip install -r requirements/amd.txt
 ```
 
 ------

--- a/docs/pt/README.pt.md
+++ b/docs/pt/README.pt.md
@@ -1,12 +1,12 @@
 <div align="center">
 
-<h1>Retrieval-based-Voice-Conversion-WebUI</h1>
-Uma estrutura de conversão de voz fácil de usar baseada em VITS.<br><br>
+# Retrieval-based-Voice-Conversion-WebUI
+Uma estrutura de conversão de voz fácil de usar baseada em VITS.
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange
 )](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Licence](https://img.shields.io/github/license/fumiama/Retrieval-based-Voice-Conversion-WebUI?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -186,7 +186,5 @@ python web.py
   + The pretrained model is trained and tested by [yxlllc](https://github.com/yxlllc/RMVPE) and [RVC-Boss](https://github.com/RVC-Boss).
   
 ## Thanks to all contributors for their efforts
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)
 

--- a/docs/tr/README.tr.md
+++ b/docs/tr/README.tr.md
@@ -1,13 +1,13 @@
 
 <div align="center">
 
-<h1>Çekme Temelli Ses Dönüşümü Web Arayüzü</h1>
-VITS'e dayalı kullanımı kolay bir Ses Dönüşümü çerçevesi.<br><br>
+# Çekme Temelli Ses Dönüşümü Web Arayüzü
+VITS'e dayalı kullanımı kolay bir Ses Dönüşümü çerçevesi.
 
 [![madewithlove](https://img.shields.io/badge/made_with-%E2%9D%A4-red?style=for-the-badge&labelColor=orange
 )](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI)
 
-<img src="https://counter.seku.su/cmoe?name=rvc&theme=r34" /><br>
+![moe](https://counter.seku.su/cmoe?name=rvc&theme=r34)
 
 [![Lisans](https://img.shields.io/github/license/fumiama/Retrieval-based-Voice-Conversion-WebUI?style=for-the-badge)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/blob/main/LICENSE)
 [![Huggingface](https://img.shields.io/badge/🤗%20-Spaces-yellow.svg?style=for-the-badge)](https://huggingface.co/lj1995/VoiceConversionWebUI/tree/main/)
@@ -147,7 +147,5 @@ Windows veya macOS kullanıyorsanız, `RVC-beta.7z` dosyasını indirip çıkara
   + Ön eğitimli model [yxlllc](https://github.com/yxlllc/RMVPE) ve [RVC-Boss](https://github.com/RVC-Boss) tarafından eğitilip test edilmiştir.
   
 ## Katkıda Bulunan Herkese Teşekkürler
-<a href="https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors" target="_blank">
-  <img src="https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI" />
-</a>
+[![contributors](https://contrib.rocks/image?repo=fumiama/Retrieval-based-Voice-Conversion-WebUI)](https://github.com/fumiama/Retrieval-based-Voice-Conversion-WebUI/graphs/contributors)
 ```

--- a/docs/tr/README.tr.md
+++ b/docs/tr/README.tr.md
@@ -71,13 +71,13 @@ Ayrıca bunları pip kullanarak da kurabilirsiniz:
 ```bash
 
 Nvidia grafik kartları için
-  pip install -r requirements/requirements.txt
+  pip install -r requirements/main.txt
 
 AMD/Intel grafik kartları için：
-  pip install -r requirements/requirements-dml.txt
+  pip install -r requirements/dml.txt
 
 Intel ARC grafik kartları için Linux / WSL ile Python 3.10 kullanarak: 
-  pip install -r requirements/requirements-ipex.txt
+  pip install -r requirements/ipex.txt
 
 ```
 


### PR DESCRIPTION
using HTML in markdown is not a good practice in general, however some things that exist in HTML do not yet exist in markdown, such as centering a sector of text; therefore `<div align="center"></div>` can not be removed without altering the looks of the README.

reading through all of the README files made me realize how most of them are outdated... gonna work on that at some point though