### PR TITLE
perf: improve codec handling in load_filepaths_and_text function in `infer.lib.train.utils`

### DIFF
--- a/infer/lib/train/utils.py
+++ b/infer/lib/train/utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sys
 
+import codecs
 import numpy as np
 import torch
 from scipy.io.wavfile import read
@@ -251,13 +252,11 @@ def load_wav_to_torch(full_path):
 
 def load_filepaths_and_text(filename, split="|"):
     try:
-        with open(filename, encoding="utf-8") as f:
-            filepaths_and_text = [line.strip().split(split) for line in f]
-    except UnicodeDecodeError:
-        with open(filename) as f:
-            filepaths_and_text = [line.strip().split(split) for line in f]
+        return [line.strip().split(split) for line in codecs.open(filename, encoding="utf-8")]
+    except UnicodeDecodeError as e:
+        logger.error("Error loading file %s: %s", filename, e)
 
-    return filepaths_and_text
+    return []
 
 
 def get_hparams(init=True):


### PR DESCRIPTION
this change incorporates usage of `codecs` module to dynamically guess the encoding of the file and convert it to pure utf-8. results of this convertion should be pure and work as intended. the idea is to not to open the file AGAIN if the UnicodeDecodeError occurs. The only possible downside is that if the encoding can not be translated to utf-8 directly (rare case) - the file will not be properly opened at all.

However, the try-except block can be dropped if the codec is guaranteed to not be non-convertible to UTF-8