### PR TITLE
chore: declare usable classes in the rvc/f0 submodule

### DIFF
--- a/rvc/f0/__init__.py
+++ b/rvc/f0/__init__.py
@@ -5,3 +5,5 @@ from .dio import Dio
 from .harvest import Harvest
 from .pm import PM
 from .rmvpe import RMVPE
+
+__all__ = ["F0Predictor", "CRePE", "Dio", "Harvest", "PM", "RMVPE"]


### PR DESCRIPTION
this way those modules can be used via `rvc.<MODULE_NAME>`
