### PR TITLE
fix(macos): disable OpenMP parallelism to prevent segmentation fault

### DIFF
--- a/web.py
+++ b/web.py
@@ -9,6 +9,7 @@ load_dotenv("sha256.env")
 
 if sys.platform == "darwin":
     os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+    os.environ["OMP_NUM_THREADS"] = "1"
 
 from infer.modules.vc import VC, show_info, hash_similarity
 from infer.modules.uvr5.modules import uvr


### PR DESCRIPTION
# PR type

- Bug fix

# Description

- This pull request addresses an issue specific to macOS, where a segmentation fault occurs when selecting an inferencing voice from the model inference tab. The fix involves disabling OpenMP parallelism on macOS by setting the OMP_NUM_THREADS environment variable to 1.
- The error message is: `[1] 93093 segmentation fault  python3 web.py --pycmd python /Users/dev/miniconda3/envs/rvc/lib/python3.8/multiprocessing/resource_tracker.py:216: UserWarning: resource_tracker: There appear to be 1 leaked semaphore objects to clean up at shutdown.`
- This change affects the initialization process where environment variables are set. It limits the number of OpenMP threads to one on macOS, which might affect performance but can't be confirmed as the segmentation fault occurs with any other values.
- This fix was tested on macOS Sonoma 14.5 (23F79) with Apple M3 silicon.